### PR TITLE
pro/Crear ruta 'animal/isPregnant' + fns aux

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -8,7 +8,7 @@ db.sequelize.sync({ alter: true }).then(() => {
     console.log(
       "**** **** **** **** **** **** **** **** **** **** **** **** **** **** **** "
     );
-    console.log(`App listening on post ${PORT}`);
+    console.log(`App listening on port ${PORT}`);
     console.log(
       "**** **** **** **** **** **** **** **** **** **** **** **** **** **** **** "
     );

--- a/api/src/routes/animal/animal-r-auxiliary.ts
+++ b/api/src/routes/animal/animal-r-auxiliary.ts
@@ -1,4 +1,5 @@
-import { ITypeOfAnimal } from "../../types/animal-types";
+import db from "../../models";
+import { IAnimal, ITypeOfAnimal } from "../../types/animal-types";
 
 export function typesOfAnimalsToArray(): string[] {
   try {
@@ -7,5 +8,59 @@ export function typesOfAnimalsToArray(): string[] {
   } catch (error: any) {
     console.log(`Error en fn typesOfAnimalsToArray. ${error.message}`);
     throw new Error(error.message);
+  }
+}
+
+export async function getAndParseIsPregnantQuery(
+  userId: any, //! cambiar a STRING
+  status: boolean,
+  order: string
+) {
+  try {
+    // Si status de is_pregnant es falso:
+    if (!status) {
+      const listOfAnimalsNotPregnant: IAnimal[] = await db.Animal.findAll({
+        where: {
+          is_pregnant: false,
+          // UserId: userId,
+        },
+      });
+      return {
+        total: listOfAnimalsNotPregnant.length,
+        list: listOfAnimalsNotPregnant,
+      };
+    }
+    // Si order es un valor válido, buscar los animales que están embarazados y en orden:
+    if (order === "ASC" || order === "DESC" || order === "NULLS FIRST") {
+      const listOfAnimalsOrdered: IAnimal[] = await db.Animal.findAll({
+        where: {
+          is_pregnant: true,
+          // UserId: userId,
+        },
+        order: [["delivery_date", order]],
+      });
+      return {
+        total: listOfAnimalsOrdered.length,
+        list: listOfAnimalsOrdered,
+      };
+    }
+    // Si el valor de orden es falsy, buscar todos los animales embarazados:
+    if (!order && status === true) {
+      const listOfAnimalsPregnant: IAnimal[] = await db.Animal.findAll({
+        where: {
+          is_pregnant: status,
+          // UserId: userId,
+        },
+      });
+      return {
+        total: listOfAnimalsPregnant.length,
+        list: listOfAnimalsPregnant,
+      };
+    }
+  } catch (error: any) {
+    console.log(`Error en fn aux getAndParseIsPregnantQuery. ${error.message}`);
+    throw new Error(
+      `Error al buscar y parsear con queries relacionados a animales preñados o no preñados.`
+    );
   }
 }

--- a/api/src/routes/animal/animal-routes.ts
+++ b/api/src/routes/animal/animal-routes.ts
@@ -9,7 +9,11 @@ import {
   userIsRegisteredInDB,
 } from "../user/user-r-auxiliary";
 import { Op } from "sequelize";
-import { typesOfAnimalsToArray } from "./animal-r-auxiliary";
+import {
+  getAndParseIsPregnantQuery,
+  typesOfAnimalsToArray,
+} from "./animal-r-auxiliary";
+import { stringToBoolean } from "../../validators/generic-validators";
 const router = Router();
 
 // ------- RUTAS : ---------
@@ -184,6 +188,33 @@ router.get("/typesAllowed", async (req, res) => {
     return res.status(200).send(typesOfAnimalsArray);
   } catch (error: any) {
     console.log(`Error en GET 'animal/typesAllowed. ${error.message}`);
+    return res.status(400).send({ error: error.message });
+  }
+});
+
+//! PARSED FOR STATS: ------------------
+// GET ALL IS PREGNANT TRUE || FALSE & ORDERED BY DELIVERY DATE :
+//Ruta de ejemplo:  localhost:3001/animal/isPregnant?status=true&order=ASC
+router.get("/isPregnant", async (req: any, res) => {
+  try {
+    // espero req.query.status = true || false
+    //URL Ej:  /animal/isPregnant?status=true || false
+    console.log(req.query);
+    console.log("req.query.status = ", req.query.status);
+    // const reqAuth: IReqAuth = req.auth;
+    // const userId = reqAuth.sub;
+    let status = req.query.status;
+    let statusParsed: boolean = stringToBoolean(status);
+    let order = req.query.order; // ASC || DESC || NULLS FIRST
+
+    const querySearchResult = await getAndParseIsPregnantQuery(
+      undefined,
+      statusParsed,
+      order
+    );
+    return res.status(200).send(querySearchResult);
+  } catch (error: any) {
+    console.log(`Error en '/animal/isPregnant. ${error.message}`);
     return res.status(400).send({ error: error.message });
   }
 });

--- a/api/src/validators/generic-validators.ts
+++ b/api/src/validators/generic-validators.ts
@@ -135,3 +135,14 @@ export function isValidURLImage(argumento: any): boolean {
     null
   );
 }
+
+// PARSE STRING TO BOOLEAN :
+export function stringToBoolean(argumento: any): boolean {
+  if (argumento === "true") {
+    return true;
+  }
+  if (argumento === "false") {
+    return false;
+  }
+  throw new Error(`El argumento '${argumento}' es inválido.`);
+}


### PR DESCRIPTION
Back-end: 
- Crear ruta 'animal/isPregnant' que acepta dos valores por query: status y order.
Ejemplo de ruta a este endpoint: localhost:3001/animal/isPregnant?status=true&order=ASC 
el status puede ser true o false. Si es false, devuelve un objeto {total: numeroDeLengthDeArray, list: [{animal},{animal}...]}
 El order es optativo, y es para ordenar de forma ASC, DESC o NULLS FIRST el listado en caso de que el status === "true".
 Devuelve un objeto igual al anterior, con total y list  keys.

- Arreglar typo en clog de listen()