### PR TITLE
fix/Arreglar <div> adentro de <p> en comp PropsColumns + cambiar prop de stats

### DIFF
--- a/api/src/routes/animal/animal-r-auxiliary.ts
+++ b/api/src/routes/animal/animal-r-auxiliary.ts
@@ -67,8 +67,8 @@ export async function getAndParseIsPregnantQuery(
 
 const stats = {
   numberOfTotalAnimals: 211,
-  pregnants: { total: 11, list: [{}, {}] },
-  notPregnants: { total: 76, list: [{}, {}, {}] },
+  pregnant: { total: 11, list: [{}, {}] },
+  notPregnant: { total: 76, list: [{}, {}, {}] },
   races: {
     ["Angus"]: { listLength: 3, list: [{}, {}, {}, {}] },
     ["Criolla"]: { listLength: 2, list: [{}, {}] },

--- a/client/src/components/PropsColumns/PropsColumns.jsx
+++ b/client/src/components/PropsColumns/PropsColumns.jsx
@@ -80,9 +80,9 @@ export function PropsColumns({ animals }) {
                     </p>
                   </td>
                   <td className="px-5 py-5 border-b border-gray-200 bg-white text-sm">
-                    <p className="text-gray-900 whitespace-no-wrap capitalize">
+                    <div className="text-gray-900 whitespace-no-wrap capitalize">
                       <AnimalCard animal={animal} />
-                    </p>
+                    </div>
                   </td>
                 </tr>
               ))}{" "}


### PR DESCRIPTION
Front-end:
- Fix de renderizado de una div adentro de una p en componente PropsColumns.

Back-end: 
- Cambiar nombre de unas props en el obj stats que al momento sirve sólo para visualizar una idea de cómo podría ser un objeto que compila datos relevantes para estadísticas.